### PR TITLE
Fix typo in coda_get.sh

### DIFF
--- a/run_scripts/1_coda_get.sh
+++ b/run_scripts/1_coda_get.sh
@@ -33,5 +33,5 @@ for DATASET in ${DATASETS[@]}
 do
     echo "Getting messages data from ${DATASET}..."
 
-    pipenv run python get.py "$AUTH" "${DATASETS}" messages >"$DATA_ROOT/Coded Coda Files/$DATASET.json"
+    pipenv run python get.py "$AUTH" "${DATASET}" messages >"$DATA_ROOT/Coded Coda Files/$DATASET.json"
 done


### PR DESCRIPTION
Deleted one extraneous character, which was causing all the coda datasets to contain s01e01, even the demogs.

Fixed on the server with nano for speed. When you merge this, please overwrite my local change and make sure the repo is clean.